### PR TITLE
emit connect event on succesfull connection

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -364,6 +364,7 @@ Client.prototype.setupHandlers = function() {
 
   stream.on('connect', function() {
     client.connected = true;
+    client.emit('connect');
   });
 
   stream.on('close', function(hadError) {


### PR DESCRIPTION
When a websocket connection fails, I can listen to the 'error' event to handle the error case, but there is no way to handle the succesfull case. All I can do is to just continue using the NATS topic sequentially after the connect, but that code will run also for the error case, which is not desired.